### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.7.0
 
 workflows:
   package-and-push-chart-on-tag:

--- a/helm/azure-logs-workspace-app/Chart.yaml
+++ b/helm/azure-logs-workspace-app/Chart.yaml
@@ -11,5 +11,5 @@ sources:
 dependencies:
 - name: fluent-logshipping-app
   version: "0.5.2"
-  repository: "https://giantswarm.github.com/giantswarm-playground-catalog"
+  repository: "https://giantswarm.github.io/giantswarm-playground-catalog"
 version: [[ .Version ]]


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898